### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "echo hello world"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project runs on Linux Operating System.
 
 ##Compiling and Running 
 
-```bash
+```bash[![Run on Repl.it](https://repl.it/badge/github/kyoheinagano544/pokemon-skyblue-3d)](https://repl.it/github/kyoheinagano544/pokemon-skyblue-3d)
 $ g++ mainPage.cpp -lGL -lGLU -lglut -o SkyBlue3D && ./SkyBlue3D
 ```
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@XxStabberXx/pokemon-skyblue-3d-5).